### PR TITLE
key for debian repo changed, and hkp needs port 80

### DIFF
--- a/Downloads/GNU-Linux/Debian/FOOTER.html
+++ b/Downloads/GNU-Linux/Debian/FOOTER.html
@@ -85,7 +85,7 @@
   the key can be accomplished by the following single command
 </p>
 <pre>
-    sudo apt-key adv --keyserver hkp://keys.gnupg.net --recv-key CD9C0E09B0C780943A1AD85553F8BD99F40DCB31
+    sudo apt-key adv --keyserver hkp://keys.gnupg.net:80 --recv-key 53F8BD99F40DCB31
 </pre>
 
 <p>


### PR DESCRIPTION
I've just installed M2 on a Debian stretch machine, and
instructions for getting the repo key were outdated, I suppose.