### PR TITLE
www.math.uiuc.edu --> www2.macaulay2.com

### DIFF
--- a/Citing/README.html
+++ b/Citing/README.html
@@ -5,7 +5,7 @@
 <pre>        @Misc{M2,
           author = {Grayson, Daniel R. and Stillman, Michael E.},
           title = {Macaulay2, a software system for research in algebraic geometry},
-          howpublished = {Available at \url{http://www.math.uiuc.edu/Macaulay2/}}
+          howpublished = {Available at \url{http://www2.macaulay2.com}}
         }</pre>
 <p>
   The macro <tt>\url</tt> is provided by the hyperref macro package; to get it, add

--- a/Style/trailer.html
+++ b/Style/trailer.html
@@ -17,7 +17,7 @@
 	  <form action="https://www.google.com/search">
 	    <div>
 	      <input type="text"   name="q">
-	      <input type="hidden" name="q" value="site:www.math.uiuc.edu inurl:Macaulay2">
+	      <input type="hidden" name="q" value="site:www2.macaulay2.com inurl:Macaulay2">
 	    </div>
 	  </form>
 	</li>


### PR DESCRIPTION
This is an attempt to replace all links to `uiuc.edu` with links to `macaulay2.com`.

Here are other potential things to look at
- `.htaccess` mentions `uiuc` a lot (and also seems to be outdated)  
- is it possible to have version-independent links? (see https://github.com/Macaulay2/M2/issues/2806)
- [`404.html`](https://github.com/Macaulay2/Macaulay2-web-site/blob/new-master/404.html)
- Downloads
- Events
- Book