### PR TITLE
Remove Ubuntu 22.10 from list of supported releases in PPA

### DIFF
--- a/Downloads/GNU-Linux/Ubuntu/FOOTER0.html
+++ b/Downloads/GNU-Linux/Ubuntu/FOOTER0.html
@@ -24,7 +24,6 @@
 <!--U-->Ubuntu 18.04 "Bionic Beaver",
 <!--U-->Ubuntu 20.04 "Focal Fossa",
 <!--U-->Ubuntu 22.04 "Jammy Jellyfish",
-<!--U-->Ubuntu 22.10 "Kinetic Kudu",
 <!--U-->and
 <!--U-->Ubuntu 23.04 "Lunar Lobster"
 <!--D-->Debian 11 "Bullseye"


### PR DESCRIPTION
It has reached end of life and the packages have been removed.