### PR TITLE
Add Ubuntu 23.10 to list of support releases in PPA

### DIFF
--- a/Downloads/GNU-Linux/Ubuntu/FOOTER0.html
+++ b/Downloads/GNU-Linux/Ubuntu/FOOTER0.html
@@ -24,8 +24,9 @@
 <!--U-->Ubuntu 18.04 "Bionic Beaver",
 <!--U-->Ubuntu 20.04 "Focal Fossa",
 <!--U-->Ubuntu 22.04 "Jammy Jellyfish",
+<!--U-->Ubuntu 23.04 "Lunar Lobster",
 <!--U-->and
-<!--U-->Ubuntu 23.04 "Lunar Lobster"
+<!--U-->Ubuntu 23.10 "Mantic Minotaur"
 <!--D-->Debian 11 "Bullseye"
 <!--D-->and
 <!--D-->Debian 12 "Bookworm"


### PR DESCRIPTION
This is already live on the website (https://macaulay2.com/Downloads/GNU-Linux/Ubuntu/index.html)