### PR TITLE
Updates for 1.23

### DIFF
--- a/Style/trailer.html
+++ b/Style/trailer.html
@@ -22,27 +22,12 @@
 	  </form>
 	</li>
 
-	<!-- 
-	   We give links to the documentation for two versions.  One reason to do that, is to give time for
-	   google to index the new one.
-	  -->
-
 	<li>
-	  <div>just the documentation (current stable version):</div>
+	  <div>just the documentation:</div>
 	  <form action="https://www.google.com/search">
 	    <div>
 	      <input type="text"   name="q">
-	      <input type="hidden" name="q" value="site:www2.macaulay2.com/Macaulay2/doc/Macaulay2">
-	    </div>
-	  </form>
-	</li>
-
-	<li>
-	  <div>just the documentation (version 1.21):</div>
-	  <form action="https://www.google.com/search">
-	    <div>
-	      <input type="text"   name="q">
-	      <input type="hidden" name="q" value="site:www2.macaulay2.com/Macaulay2/doc/Macaulay2-1.21">
+	      <input type="hidden" name="q" value="site:macaulay2.com/doc">
 	    </div>
 	  </form>
 	</li>

--- a/Style/trailer.html
+++ b/Style/trailer.html
@@ -71,7 +71,7 @@
 
     <li class="bbox extra_space_below"> Documentation
       <ul>
-	<li><a href="/Macaulay2/doc/Macaulay2-1.22/share/doc/Macaulay2/Macaulay2Doc/html/">stable</a></li>
+	<li><a href="/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Macaulay2Doc/html/">stable</a></li>
       </ul>
     </li>
 
@@ -96,8 +96,8 @@
     <li class="bbox extra_space_below"> <a href="/Macaulay2/Downloads/">Downloads</a>
       <ul>
 	<li> (the current stable version is 1.22, released July 1, 2023)</li>
-	<li> <a href="/Macaulay2/doc/Macaulay2-1.22/share/doc/Macaulay2/Macaulay2Doc/html/_changes_spto_sp__Macaulay2_cm_spby_spversion.html">Changes, by version</a> </li>
-	<li> <a href="/Macaulay2/doc/Macaulay2-1.22/share/doc/Macaulay2/Macaulay2Doc/html/_packages_spprovided_spwith_sp__Macaulay2.html">Packages</a> for Macaulay2 that extend its functionality </li>
+	<li> <a href="/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Macaulay2Doc/html/_changes_spto_sp__Macaulay2_cm_spby_spversion.html">Changes, by version</a> </li>
+	<li> <a href="/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Macaulay2Doc/html/_packages_spprovided_spwith_sp__Macaulay2.html">Packages</a> for Macaulay2 that extend its functionality </li>
 	<li> <a href="/Macaulay2/PublicKeys/">Public key</a> for Macaulay2, used to sign files </li>
 	<li> <a href="https://github.com/Macaulay2/M2">Source code</a>, on github</li>
 	<!-- There are just two, rather old, answers here.  The google group is much better now

--- a/Style/trailer.html
+++ b/Style/trailer.html
@@ -95,7 +95,7 @@
 
     <li class="bbox extra_space_below"> <a href="/Macaulay2/Downloads/">Downloads</a>
       <ul>
-	<li> (the current stable version is 1.22, released July 1, 2023)</li>
+	<li> (the current stable version is 1.23, released March 20, 2024)</li>
 	<li> <a href="/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Macaulay2Doc/html/_changes_spto_sp__Macaulay2_cm_spby_spversion.html">Changes, by version</a> </li>
 	<li> <a href="/Macaulay2/doc/Macaulay2/share/doc/Macaulay2/Macaulay2Doc/html/_packages_spprovided_spwith_sp__Macaulay2.html">Packages</a> for Macaulay2 that extend its functionality </li>
 	<li> <a href="/Macaulay2/PublicKeys/">Public key</a> for Macaulay2, used to sign files </li>


### PR DESCRIPTION
We update the website to mention that the latest release is 1.23.  Also, we remove a few hardcoded version numbers from URL's.  They aren't necessary since `Macaulay2` exists as a symlink to the directory containing the docs for the most recent version.  We also update the documentation search bar to match the one that exists in the documentation.  (Only one bar, which uses the main site instead of the `www2` mirror.)