### PR TITLE
Remove "sh" in call to index-new-html in Red Hat directory

### DIFF
--- a/Downloads/GNU-Linux/Red Hat Enterprise, CentOS, Scientific Linux/Makefile
+++ b/Downloads/GNU-Linux/Red Hat Enterprise, CentOS, Scientific Linux/Makefile
@@ -1,3 +1,3 @@
 include ../../../Makefile.include
 OPTIONS := -t "$(shell echo `pwd`/../../../Style/trailer.html)"
-index-new-local:; sh index-new-html -l $(OPTIONS)
+index-new-local:; index-new-html -l $(OPTIONS)


### PR DESCRIPTION
It was giving me the following when I tried rebuilding the file list on the website:

```
sh index-new-html -l -t "/var/www/www2.macaulay2.com/Downloads/GNU-Linux/Red Hat Enterprise, CentOS, Scientific Linux/../../../Style/trailer.html"
sh: 0: Can't open index-new-html
Makefile:3: recipe for target 'index-new-local' failed
make: *** [index-new-local] Error 127
```