### PR TITLE
Update wiki link and drop announcements link

### DIFF
--- a/Style/trailer.html
+++ b/Style/trailer.html
@@ -72,9 +72,7 @@
 	    <img src="/Macaulay2/Style/feed-icon-14x14.png" class="topalign" width="14" height="14" alt=""> Subscribe <b>...</b></a></li>
 	-->
 	<li> <a href="https://github.com/Macaulay2/M2/wiki/Projects">Projects</a> undertaken or proposed</li>
-	<li> <a href="http://wiki.macaulay2.com/">Macaulay2 Wikis</a></li>
-	<li> <a href="mailto:dan@math.uiuc.edu">Announcements</a>: send email to register for the mailing list </li>
-
+	<li> <a href="https://github.com/Macaulay2/M2/wiki">Macaulay2 Wikis</a></li>
       </ul>
     </li>
 


### PR DESCRIPTION
We update the wiki link to point to the GitHub wiki and drop the announcements link.  It pointed to Dan's old math.uiuc.edu email, which I think might not exist any more?  We already have a link to the Google group, which seems like the natural replacement.